### PR TITLE
Fixed a bug where product category was missing

### DIFF
--- a/CORE/app/Controllers/Admin/Control/Catalog/Product/ListMod.php
+++ b/CORE/app/Controllers/Admin/Control/Catalog/Product/ListMod.php
@@ -54,6 +54,8 @@ class ListMod extends AdminController
 
         $data['catalog_category'] = $this->catalogCategory(1);
 
+        if ($data['catalog_category'] == null) return $this->viewPage('control/catalog/product/lists/error/index', $data);
+
         return $this->viewPage('control/catalog/product/lists/new/index', $data);
     }
 
@@ -64,6 +66,8 @@ class ListMod extends AdminController
         $data = [];
         $data['catalog_data'] = $this->catalogData(1, $id);
         $data['catalog_category'] = $this->catalogCategory(1);
+
+        if ($data['catalog_category'] == null) return $this->viewPage('control/catalog/product/lists/error/index', $data);
 
         if ($data['catalog_data'] == null) return $this->error404();
 

--- a/CORE/app/Views/_admin/control/catalog/product/lists/error/body.php
+++ b/CORE/app/Views/_admin/control/catalog/product/lists/error/body.php
@@ -1,0 +1,10 @@
+<div class="tx_w_bolder">
+    Kategori produk belum ada
+</div>
+<div class="block mt0c5">
+    Anda harus menambahkan kategori produk sebelum menambahkan atau mengatur data produk
+    <br>
+    <a href="<?= adminUrl('catalog/product/category/new'); ?>" class="button1 mt1 wd_fit">
+        Tambah kategori produk
+    </a>
+</div>

--- a/CORE/app/Views/_admin/control/catalog/product/lists/error/head.php
+++ b/CORE/app/Views/_admin/control/catalog/product/lists/error/head.php
@@ -1,0 +1,17 @@
+<div class="head_title">
+    <div class="title">
+        Peringatan !!!
+    </div>
+</div>
+
+<script type="text/javascript">
+    // 
+    $('body')
+        .find('*[class*="panel_container"] .content_container').on('scroll', function() {
+
+            let scrollPosY = $(this).scrollTop();
+
+            if (scrollPosY > 5) $(this).find('.content_head').addClass('active');
+            else $(this).find('.content_head').removeClass('active');
+        });
+</script>

--- a/CORE/app/Views/_admin/control/catalog/product/lists/error/index.php
+++ b/CORE/app/Views/_admin/control/catalog/product/lists/error/index.php
@@ -1,0 +1,26 @@
+<?= $this->extend("{$base_path}/control/layout/layout.php"); ?>
+
+<!-- Pre-process - Start -->
+
+
+<!-- Pre-process - Finish -->
+
+<!-- Content Head - Start -->
+<?= $this->section('content_head'); ?>
+
+<div class="content_head">
+    <?php include("head.php"); ?>
+</div>
+
+<?= $this->endSection('content_head'); ?>
+<!-- Content Head - Finish -->
+
+<!-- Content Body - Start -->
+<?= $this->section('content_body'); ?>
+
+<div class="content_body">
+    <?php include("body.php"); ?>
+</div>
+
+<?= $this->endSection('content_body'); ?>
+<!-- Content Body - Finish -->


### PR DESCRIPTION
When uploading a product, there must be at least 1 product category. If the product category does not exist, a warning will be displayed